### PR TITLE
Autofind rules when box ticked

### DIFF
--- a/orangecontrib/associate/widgets/owassociate.py
+++ b/orangecontrib/associate/widgets/owassociate.py
@@ -90,7 +90,7 @@ class OWAssociate(widget.OWWidget):
         self.cb_classify = gui.checkBox(
             box, self, 'classify', label='Induce classification (itemset → class) rules')
         self.button = gui.auto_commit(
-                box, self, 'autoFind', 'Find rules', commit=self.find_rules)
+                box, self, 'autoFind', 'Find rules', callback=self.find_rules)
 
         vbox = gui.widgetBox(self.controlArea, 'Filter rules')
 


### PR DESCRIPTION
When the Autofind Rules box was ticked, nothing happened. Now, upon ticking the box, the command is run.