### PR TITLE
[FIX] Frequent Itemsets: initialize data

### DIFF
--- a/orangecontrib/associate/widgets/owitemsets.py
+++ b/orangecontrib/associate/widgets/owitemsets.py
@@ -55,6 +55,7 @@ class OWItemsets(widget.OWWidget):
     ]
 
     def __init__(self):
+        self.data = None
         self._is_running = False
         self.isRegexMatch = lambda x: True
         self.tree = QTreeWidget(self.mainArea,


### PR DESCRIPTION
##### Issue
Widget fails if one clicks _Find Itemsets_ or checkbox near that button is checked and `self.data` has not been declared yet.

##### Description of changes
`self.data` is now set to `None` in `__init__`.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
