### PR TITLE
[FIX] Frequent Itemsets: self.output defined in init

### DIFF
--- a/orangecontrib/associate/widgets/owitemsets.py
+++ b/orangecontrib/associate/widgets/owitemsets.py
@@ -56,6 +56,7 @@ class OWItemsets(widget.OWWidget):
 
     def __init__(self):
         self.data = None
+        self.output = None
         self._is_running = False
         self.isRegexMatch = lambda x: True
         self.tree = QTreeWidget(self.mainArea,


### PR DESCRIPTION
##### Issue
`self.output` is not defined in `__init__`.

##### Description of changes


##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
