### PR TITLE
Travis configuration for Py3.6 and Py3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,28 @@
 language: python
 sudo: false
-dist: trusty
-python: "3.5"
+dist: xenial
+
+matrix:
+  include:
+
+    - python: '3.7'
+      env: ORANGE="3.20.0"
+
+    - python: '3.6'
+      env: ORANGE="release"
+
+    - python: '3.7'
+      env: ORANGE="release"
+
+    - python: '3.7'
+      env: ORANGE="master"
 
 cache:
     apt: true
     pip: true
     ccache: true
+    directories:
+        - $TRAVIS_BUILD_DIR/pyqt
 
 before_install:
     - pip install -U setuptools pip wheel
@@ -14,11 +30,13 @@ before_install:
 
 install:
     - pip install PyQt5 AnyQt
-    - pip install Orange3
-    - travis_wait pip install -e .
+    - source $TRAVIS_BUILD_DIR/.travis/install_orange.sh
+    - pip install -e .
 
 script:
-    - catchsegv xvfb-run -a -s "-screen 0 1280x1024x24" coverage run setup.py test
+    - XVFBARGS="-screen 0 1280x1024x24"
+    - catchsegv xvfb-run -a -s "$XVFBARGS" coverage run -m unittest discover -v
 
 after_success:
     - codecov
+    

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false
 dist: xenial
 
 matrix:
@@ -39,4 +38,3 @@ script:
 
 after_success:
     - codecov
-    

--- a/.travis/install_orange.sh
+++ b/.travis/install_orange.sh
@@ -1,0 +1,14 @@
+if [ $ORANGE == "release" ]; then
+    echo "Orange: Skipping separate Orange install"
+    return 0
+fi
+
+if [ $ORANGE == "master" ]; then
+    echo "Orange: from git master"
+    pip install https://github.com/biolab/orange3/archive/master.zip
+    return $?;
+fi
+
+PACKAGE="orange3==$ORANGE"
+echo "Orange: installing version $PACKAGE"
+pip install $PACKAGE


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Orange no longer supports Python 3.5.

##### Description of changes
Update Travis to test on Python 3.6 and Python 3.7.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
