### PR TITLE
Add widget.json

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -12,8 +12,8 @@ Widgets
 .. toctree::
    :maxdepth: 1
 
-   widgets/associationrules.rst
-   widgets/frequentitemsets.rst
+   widgets/associationrules
+   widgets/frequentitemsets
 
 Scripting
 ------------

--- a/doc/widgets.json
+++ b/doc/widgets.json
@@ -1,0 +1,21 @@
+[
+ [
+  "Associate",
+  [
+   {
+    "text": "Frequent Itemsets",
+    "doc": "widgets/frequentitemsets.md",
+    "icon": "../orangecontrib/associate/widgets/icons/FrequentItemsets.svg",
+    "background": "#cccc66",
+    "keywords": []
+   },
+   {
+    "text": "Association Rules",
+    "doc": "widgets/associationrules.md",
+    "icon": "../orangecontrib/associate/widgets/icons/AssociationRules.svg.svg",
+    "background": "#cccc66",
+    "keywords": []
+   }
+  ]
+ ]
+]


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Website requires widget.json to display docs.

##### Description of changes
Add widget.json.
File generated with:
`python ~/orange/orange-hugo/scripts/create_widget_catalog.py  --categories "Associate" --doc .`

Association Rules added manually since script was somehow unable to find it.

##### Includes
- [ ] Code changes
- [ ] Tests
- [X] Documentation
