### PR TITLE
Documentation: enable building with html builder

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -35,6 +35,7 @@ sys.path.insert(0, join(dirname(dirname(__file__)), 'orangecontrib', 'associate'
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
+    'recommonmark'
 ]
 
 autodoc_member_order = 'bysource'

--- a/orangecontrib/associate/widgets/__init__.py
+++ b/orangecontrib/associate/widgets/__init__.py
@@ -11,9 +11,9 @@ BACKGROUND = "#cccc66"
 WIDGET_HELP_PATH = (
     # Used for development.
     # You still need to build help pages using
-    # make htmlhelp
+    # make html
     # inside doc folder
-    ("{DEVELOP_ROOT}/doc/_build/htmlhelp/index.html", None),
+    ("{DEVELOP_ROOT}/doc/_build/html/index.html", None),
 
     # Online documentation url, used when the local documentation is available.
     # Url should point to a page with a section Widgets. This section should


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
In https://github.com/biolab/orange3-educational/pull/109 we changed the documentation theme to shpinx rtd theme. It was found out that it does not support htmlhelp builder. 

##### Description of changes
Since with this theme, it is not required to build the documentation with htmlhelp I am changing the setting such that they are compatible with html builder. From now on we build documentation with `make html` instead of `make htmlhelp`


##### Includes
- [ ] Code changes
- [ ] Tests
- [X] Documentation
