### PR TITLE
Python310 compatibility

### DIFF
--- a/orangecontrib/associate/fpgrowth.py
+++ b/orangecontrib/associate/fpgrowth.py
@@ -149,7 +149,8 @@ Reference with further examples below.
 # TODO: Consider FPClose from "Efficiently using prefix-trees in mining frequent itemsets"
 # TODO: Consider ExAnte: Anticipated data reduction in constrained pattern mining
 
-from collections import defaultdict, Iterator
+from collections import defaultdict
+from collections.abc import Iterator
 from itertools import combinations, chain
 from functools import reduce
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Orange3-associate is not Python3.10 compatible
Conda-forge python3.10 build fails https://github.com/conda-forge/orange3-associate-feedstock/pull/3

##### Description of changes
fpgrowth: import Iterator from collections.abc instead from collections

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
