### PR TITLE
Use QApplication.instance() instead of qApp (Qt6 compatibility)

### DIFF
--- a/orangecontrib/associate/widgets/owassociate.py
+++ b/orangecontrib/associate/widgets/owassociate.py
@@ -6,7 +6,7 @@ from scipy.sparse import issparse
 
 from AnyQt.QtCore import Qt, QSortFilterProxyModel
 from AnyQt.QtGui import QStandardItem, QStandardItemModel
-from AnyQt.QtWidgets import QTableView, qApp, QGridLayout, QLabel
+from AnyQt.QtWidgets import QTableView, QGridLayout, QLabel, QApplication
 
 from Orange.data import Table, ContinuousVariable, StringVariable, Domain
 from Orange.widgets import widget, gui, settings
@@ -415,7 +415,7 @@ class OWAssociate(widget.OWWidget):
                     if not self._is_running or nRules >= self.maxRules:
                         break
 
-                qApp.processEvents()
+                QApplication.instance().processEvents()
 
                 if not self._is_running or nRules >= self.maxRules:
                     break

--- a/orangecontrib/associate/widgets/owitemsets.py
+++ b/orangecontrib/associate/widgets/owitemsets.py
@@ -6,7 +6,7 @@ import numpy as np
 from scipy.sparse import issparse
 
 from AnyQt.QtCore import Qt, QItemSelection, QItemSelectionModel
-from AnyQt.QtWidgets import QTreeWidget, QTreeWidgetItem, qApp
+from AnyQt.QtWidgets import QTreeWidget, QTreeWidgetItem, QApplication
 
 from Orange.data import Table
 from Orange.widgets import widget, gui, settings
@@ -297,7 +297,7 @@ class OWItemsets(widget.OWWidget):
                 if not self._is_running or nItemsets >= self.maxItemsets:
                     break
 
-                qApp.processEvents()
+                QApplication.instance().processEvents()
 
         if not filterSearch:
             self.filter_change()


### PR DESCRIPTION
##### Issue

```
2023-09-29 01:29:44,099:INFO:orangecanvas.registry.discovery: Could not import 'orangecontrib.associate.widgets.owassociate'.
Traceback (most recent call last):
  File "/home/frankc/orange/lib/python3.11/site-packages/orangecanvas/registry/discovery.py", line 309, in iter_widget_descriptions
    module = asmodule(name)
             ^^^^^^^^^^^^^^
  File "/home/frankc/orange/lib/python3.11/site-packages/orangecanvas/registry/discovery.py", line 552, in asmodule
    return __import__(module, fromlist=[""])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frankc/orange/lib/python3.11/site-packages/orangecontrib/associate/widgets/owassociate.py", line 9, in <module>
    from AnyQt.QtWidgets import QTableView, qApp, QGridLayout, QLabel
ImportError: cannot import name 'qApp' from 'AnyQt.QtWidgets' (/home/frankc/orange/lib/python3.11/site-packages/AnyQt/QtWidgets.py)
2023-09-29 01:29:44,100:INFO:orangecanvas.registry.discovery: Could not import 'orangecontrib.associate.widgets.owitemsets'.
Traceback (most recent call last):
  File "/home/frankc/orange/lib/python3.11/site-packages/orangecanvas/registry/discovery.py", line 309, in iter_widget_descriptions
    module = asmodule(name)
             ^^^^^^^^^^^^^^
  File "/home/frankc/orange/lib/python3.11/site-packages/orangecanvas/registry/discovery.py", line 552, in asmodule
    return __import__(module, fromlist=[""])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/frankc/orange/lib/python3.11/site-packages/orangecontrib/associate/widgets/owitemsets.py", line 9, in <module>
    from AnyQt.QtWidgets import QTreeWidget, QTreeWidgetItem, qApp
```

From biolab/orange3#6588

I had exact same problems with PyQt6 6.5.

##### Description of changes

qApp -> QApplication.instance()

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
