### PR TITLE
Tox - Set oldest Pandas

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ deps =
     oldest: orange3==3.33.0
     oldest: orange-canvas-core==0.1.27
     oldest: orange-widget-base==4.18.0
+    oldest: pandas==1.4.0
     latest: https://github.com/biolab/orange3/archive/refs/heads/master.zip#egg=orange3
     latest: https://github.com/biolab/orange-canvas-core/archive/refs/heads/master.zip#egg=orange-canvas-core
     latest: https://github.com/biolab/orange-widget-base/archive/refs/heads/master.zip#egg=orange-widget-base


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Tests fail since oldest supported Orange doesn't support pandas 2.1

##### Description of changes
Use pandas 1.4 (orange oldest supported) for oldest tests

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
