### PR TITLE
[FIX] Adopt Associate widget to PyQt6

### DIFF
--- a/orangecontrib/associate/widgets/owassociate.py
+++ b/orangecontrib/associate/widgets/owassociate.py
@@ -126,7 +126,10 @@ class OWAssociate(widget.OWWidget):
         table.verticalHeader().setVisible(False)
         table.verticalHeader().setDefaultSectionSize(table.verticalHeader().minimumSectionSize())
         table.horizontalHeader().setStretchLastSection(True)
-        table.setModel(QStandardItemModel(table))
+        proxy_model = self.proxy_model
+        proxy_model.setSourceModel(QStandardItemModel(table))
+        table.setModel(proxy_model)
+
         self.mainArea.layout().addWidget(table)
 
         box = gui.widgetBox(self.controlArea, "Info")
@@ -323,7 +326,8 @@ class OWAssociate(widget.OWWidget):
 
         self._is_running = True
         data = self.data
-        self.table.model().clear()
+        model = self.table.model().sourceModel()
+        model.clear()
 
         n_examples = len(data)
         NumericItem = self.NumericItem
@@ -349,7 +353,6 @@ class OWAssociate(widget.OWWidget):
                        if var is data.domain.class_var} if self.classify else set()
         assert bool(class_items) == bool(self.classify)
 
-        model = QStandardItemModel(self.table)
         for col, (label, _, tooltip) in enumerate(self.header):
             item = QStandardItem(label)
             item.setToolTip(tooltip)
@@ -424,20 +427,18 @@ class OWAssociate(widget.OWWidget):
         table = self.table
         table.setHidden(True)
         table.setSortingEnabled(False)
-        proxy_model = self.proxy_model
-        proxy_model.setSourceModel(model)
-        table.setModel(proxy_model)
+
         for i in range(model.columnCount()):
             table.resizeColumnToContents(i)
         table.setSortingEnabled(True)
         table.setHidden(False)
-        self.table_rules = proxy_model.get_data()
+        self.table_rules = self.table.model().get_data()
         self.Outputs.rules.send(self.table_rules)
 
         self.button.setText('Find Rules')
 
         self.nRules = nRules
-        self.nFilteredRules = proxy_model.rowCount()  # TODO: continue; also add in owitemsets
+        self.nFilteredRules = model.rowCount()  # TODO: continue; also add in owitemsets
         if not self.nFilteredRules:
             self.Warning.filter_no_match()
         self.nSelectedRules = 0

--- a/orangecontrib/associate/widgets/tests/test_owassociate.py
+++ b/orangecontrib/associate/widgets/tests/test_owassociate.py
@@ -29,6 +29,8 @@ class TestOWAssociate(WidgetTest):
         self.widget.find_rules()
         output = self.get_output(self.widget.Outputs.rules)
         self.assertEqual(38, len(output))
+        self.assertEqual(38, self.widget.table.model().rowCount())
+        self.assertEqual(9, self.widget.table.model().columnCount())
 
         # filter by existing column
         self.widget.filterKeywordsAntecedent = match_filter
@@ -36,6 +38,8 @@ class TestOWAssociate(WidgetTest):
         self.widget.find_rules()
         output = self.get_output(self.widget.Outputs.rules)
         self.assertEqual(5, len(output))
+        self.assertEqual(5, self.widget.table.model().rowCount())
+        self.assertEqual(9, self.widget.table.model().columnCount())
 
         # filter by non-existing word
         self.widget.filterKeywordsAntecedent = no_match_filter
@@ -44,6 +48,7 @@ class TestOWAssociate(WidgetTest):
         self.assertTrue(self.widget.Warning.filter_no_match.is_shown())
         output = self.get_output(self.widget.Outputs.rules)
         self.assertIsNone(output)
+        self.assertEqual(0, self.widget.table.model().rowCount())
 
         # run again with defaults
         self.widget.filterKeywordsAntecedent = ""


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Associate fails on PyQT6 since [QSortFilterProxyModel](https://doc.qt.io/qt-6/qsortfilterproxymodel.html) doesn't have clear attribute.

##### Description of changes
Clear source model instead. To simplify the code, connect ProxyModel to the table from the beginning.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
